### PR TITLE
WARC revision 1.1 (augmentation): add new named fields for deduplication

### DIFF
--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -15,11 +15,13 @@ This specification covers the CDXJ file format used by OpenWayback 3.0.0 (and la
 WARC and ARC files) and make them searchable via a resource resolution service.
 
 The format builds on the CDX file format originally developed by the Internet Archive for the indexing behind the WaybackMachine. 
-This specification build on it by simplifying the primary fields while adding a flexible JSON 'block' to each resource, allowing 
-high flexiblity in the inclusion of secondary data.
+This specification builds on it by simplifying the primary fields while adding a flexible JSON 'block' to each record, allowing 
+high flexiblity in the inclusion of additional data.
 
 The use of a JSON in this manner is not novel. This specification is focused on enumarating the exact fields *outside* the JSON
-and creating a list of the most common JSON fields for cross compatibility reasons. For the purposes of this document, CDXJ will be understood to refer to this particular specification.
+and creating a list of the most common JSON fields for cross compatibility reasons. 
+
+For the purposes of this document, CDXJ will be understood to refer to this particular specification.
 
 While we recognize that this format may have wider application (e.g. for data exchange) the primary purpose of this specification is
 to establish a file format suitable for creating a simple, URI keyed, index to the resources of a web archive.
@@ -28,7 +30,7 @@ to establish a file format suitable for creating a simple, URI keyed, index to t
 File Specification
 ==================
 
-Each file is a plain text file, UTF-8 encoded. It should end each line with Unix style newlines (0x0A).
+Each file is a plain text file, UTF-8 encoded. It should end each line with Unix style newline character (0x0A).
 
 A CDXJ file that has been sorted can be refered to as a CDXJ *index* as it is easily searchable.
 
@@ -36,7 +38,7 @@ A CDXJ file that has been sorted can be refered to as a CDXJ *index* as it is ea
 ## Header / Format Version
 
 Each file should begin with a line declaring the file format and file format version. This line is preceeded with a bang symbol 
-(`!` - 0x21) so that it automatically sorts to the front of the file.
+(`!` - 0x21) so that it naturally sorts to the front of the file.
 
 Example:
 
@@ -47,26 +49,26 @@ Example:
 This line may be repeated any number of times, as long as they are all sequential, starting from the first line of the file. 
 The is to accomodate the merging of multiple CDXJ files that may be generated at different times.
 
-It is permissible to mix minor version numbers (e.g. `1.0` and `1.1`) as minor versions are required to be backwards compatible.
-In this scenario, parsing software should treat the entire file based on the highest observed version number.
+It is permissible to mix minor version numbers (e.g. `1.0` and `1.1`) in the same file as minor versions are required to be backwards 
+compatible. In this scenario, parsing software should treat the entire file based on the highest observed version number.
 
 It is not permissible to mix major version numbers (e.g. `1.0` and `2.0`) in the same file. It is understood that an increase in
 the major version number indicates a change that is not backwards compatible. It is not possible to merge CDXJ files with 
 different major version numbers.
 
 
-Resource Entries
+Resource Entries / Records
 ----------------
 
-Following the header lines, each additional line should represent exactly one resource in a web archive. Typically in a WARC (ISO 28500) or ARC file, although the exact storage of the resource is not defined by this specification.
+Following the header lines, each additional line should represent exactly one resource in a web archive. Typically in a WARC (ISO 28500) or ARC file, although the exact storage of the resource is not defined by this specification. Each such line shall be refered to as a *record*.
 
 
 Field Specification
 ===================
 
-Each line is composed of five fields. 
+Each line, or record, is composed of five fields. 
 
-The fields are seperated by spaces (0x20). Consequently, spaces may not appear in the fields, except for the last field (JSON block). 
+The fields are seperated by spaces (0x20). Consequently, spaces may not appear in the fields, except for the last field (JSON block).
 
 Additionally, only the last (JSON block) field may begin with an opening curly brace (`{` - 0x7B).
 
@@ -101,7 +103,7 @@ The correct SURT transformation is ...
 
 ... once you include the third step of dropping the scheme. 
 
-Note that the first field may not begin with a bang character (`!` - 0x21). 
+The first field may not begin with a bang character (`!` - 0x21). Only header lines may begin with this character.
 
 For URI's containing an *Internationalized domain name* (IDN), this field should always use the IDN format and not the *Punycode* 
 representation.
@@ -127,28 +129,30 @@ of the timestamp should match the accuracy that is available in the WARC (or oth
 
 **Note:** All timestamps should be in UTC.
 
+In general, this field is equivalent to the WARC-Date field of a WARC record.
+
 
 Content Digest
 --------------
 
-The third field should contain a Base32 encoded SHA-1 digest of the contents of the URI. The algorithm prefix (e.g. `sha1:`) often used where multiple hashing algorithms may be used, is
-omitted in this case.
+The third field should contain a Base32 encoded SHA-1 digest of the contents of the URI. The algorithm prefix (e.g. `sha1:`) often used 
+where multiple hashing algorithms may be used, is omitted in this case.
 
 Note that this is the digest of the payload or content of the record, excluding such things as, for example, HTTP headers. Records that 
 refer to resources without such a payload (e.g. HTTP redirects) use a simple dash (`-` - 0x2D) for this field to indicate this. 
 
 In the case of revisit records and continuation records (or others that rely on a second record to fully replay the content), this should
-be the digest of the original/full content. Additional digests may be included in the JSON blob.
+be the digest of the original/full content. Additional digests may be included in the JSON block.
 
 The choice of SHA-1 hashing algorithm is based on its extremly widespread usage in web archiving. As it is not practical to have a CDXJ 
 with a mixture of digest from different algorithms here, we chose the most commonly used algorithm. Additional digests from other 
-algorithms may be included in the JSON blob.
+algorithms may be included in the JSON block.
 
 
 Record Type
 -----------
 
-Indicates what type of record the current line refers to. This field is fully compatible with WARC 1.0 (ISO 28500) definition of 
+Indicates what type of record the current line refers to. This field is fully compatible with WARC 1.0 definition of 
 WARC-Type (chapter 5.5 and chapter 6). 
 
 For content not stored in WARCs, a reasonable equivalent should be chosen.
@@ -160,15 +164,15 @@ E.g.
 * **revisit** - Suitable for any record of a response from a server to a specific request, where the content body is equal to that of another record.
 
 
-JSON 
-----
+JSON block
+----------
 
 The fifth and final field is a single line JSON block. This should contain fully valid JSON data. The only limitation, beyond those 
 imposed by JSON encoding rules, is that this may not contain any newline characters, either in Unix (0x0A) or Windows form (0x0D0A). The 
 first occurance of a 0x0A constitutes the end of this field (and the record).
 
 The order of key/value pairs within the JSON block is unspecified. It is not expected that records can be sorted, in any way, on the JSON 
-field.
+block field.
 
 It is legal to store any amount of data in the JSON block. The following keys, however have a defined meaning. Further, some of these
 fields are required.
@@ -178,7 +182,7 @@ Defined JSON keys:
 * **uri** (*required*) - The value should be the non-transformed URI used for the searchable URI (first sortable field).
 * **hsc** - HTTP Status Code. Applicable for *response* records for HTTP(S) URIs.
 * **mct** - Media Content Type (MIME type). For HTTP(S) *response* records this is typically the "Content-Type" from the HTTP header. This field, however, does not specify the origin of the information. It may be used to include content type that was derived from content analysis or other sources.
-* **ref** (*required) - A URI that resolves to the resource that this record refers to. This can be any well defined URI scheme. For the most common web archive use case of warc filename plus offset, see Appendix C. For other use cases, existing schemes can be used or new ones devised.
+* **ref** (*required*) - A URI that resolves to the resource that this record refers to. This can be any well defined URI scheme. For the most common web archive use case of warc filename plus offset, see Appendix C. For other use cases, existing schemes can be used or new ones devised.
 * **rid** (*recommended*) - Record ID. Typically WARC-Record-ID or equivalent if not using WARCs. In a mixed environment, you should ensure that record ID is unique.
 * **cle** - Content Length. The length of the content (uncompressed), ignoring WARC headers, but including any HTTP headers or similar.
 * **ple** - Payload Length. The length of the *payload* (uncompressed). The exact meaning will vary by content type, but the common case is the length of the document, excluding any HTTP headers in a HTTP response record.
@@ -188,6 +192,10 @@ Defined JSON keys:
 * **rod** (*recommended*) - Revisit Original Date. Only valid for records of type *revisit*. Contains the timestamp (equivalent to sortable field #2) of the record that this record is considered a revisit of.
 * **roi** - Revisit Original record ID. Only valid for records of type *revisit*. Contains the record ID of the record that this record is considered a revisit of.
 
+To reduce the possibility of incompatibility with future versions of CDXJ, the use of custom keys longer than 3 characters is recommended.
+
+Alternatively, new keys may be discussed and agreed upon by the OpenWayback community prior to a revised CDXJ version being released. 
+Allowing for quicker implementation of additional keys.
 
 
 Sorting File / Index
@@ -205,8 +213,8 @@ expectation of the software using the CDXJ file (typically OpenWayback). Consult
 Appendices 
 ==========
 
-A Canonicalization
---------------------
+Appendix A | Canonicalization
+-----------------------------
 
 Canonicalization is applied to URIs to remove trivial differences in the URIs that do not reflect that the URI reference different 
 resources. Examples include removing session ID parameters, unneccessary port declerations (e.g. :80 when crawling HTTP).
@@ -216,21 +224,21 @@ however, use any canonicalization scheme you care for (including none). You must
 applied to the URIs when performing searches. Otherwise they may not match correctly.
 
 
-B Sort-friendly URI Reordering Transform (SURT)
------------------------------------------------
+Appendix B | Sort-friendly URI Reordering Transform (SURT)
+----------------------------------------------------------
 
 SURT is a transformation applied to URIs which makes their left-to-right representation better match the natural hierarchy of domain 
 names.
 
-A URI <scheme://domain.tld/path?query> has SURT form <scheme://(tld,domain,)/path?query>.
+A URI `<scheme://domain.tld/path?query>` has SURT form `<scheme://(tld,domain,)/path?query>`.
 
 Conversion to SURT form also involves making all characters lowercase, and changing the 'https' scheme to 'http'. Further, the '/' after 
 a URI authority component -- for example, the third slash in a regular HTTP URI -- will only appear in the SURT form if it appeared in 
-the plain URI form. (This convention proves important when using real URIs as a shorthand for SURT prefixes, as described below.)
+the plain URI form.
 
 
-C 'warcfile' URI Scheme
------------------------
+Appendix C | 'warcfile' URI Scheme
+----------------------------------
 
 The 'warcfile' URI scheme shall be assumed to have the following structure:
 
@@ -252,8 +260,8 @@ warcfile:warcfile:IAH-20070824123353-00393-heritrix2.nb.no.arc.gz#25523382
 To fully resolve a URI with this scheme, an index mapping WARC filenames to specific locations is needed.
 
 
-D Example CDXJ File
--------------------
+Appendix D | Example CDXJ File
+------------------------------
 
 ```
 !OpenWayback-CDXJ 1.0

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -103,6 +103,9 @@ The correct SURT transformation is ...
 
 Note that the first field may not begin with a bang character (`!` - 0x21). 
 
+For URI's containing an *Internationalized domain name* (IDN), this field should always use the IDN format and not the *Punycode* 
+representation.
+
 
 Timestamp
 ---------
@@ -189,6 +192,14 @@ Defined JSON keys:
 
 Sorting File / Index
 ====================
+
+A sorted CDXJ file is considered a CDXJ *index*, allowing lookup on URI (and timestamp) using simple binary searches. The CDXJ structure 
+is designed to facilitate this, but the sorting is outside the scope of this document. A non-sorted CDXJ file is still valid as far as
+this specification goes. It is just not usable for searching.
+
+Furthermore, the structure of the CDXJ is designed so that using common sorting tools (e.g. GNU "sort" utility) works as expected. Do
+note that you may need to correctly configure the collation settings (how it orders the characters when sorting). This must match the
+expectation of the software using the CDXJ file (typically OpenWayback). Consult the software's documentation for further details.
 
 
 Appendices 

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -8,8 +8,8 @@ latest: true
 version-of: cdxj-openwayback-format
 ---
 
-# Preamble
-
+Preamble
+========
 
 This specification covers the CDXJ file format used by OpenWayback 3.0.0 (and later) to index web archive contents (notably in 
 WARC and ARC files) and make them searchable via a resource resolution service.
@@ -22,7 +22,8 @@ The use of a JSON in this manner is not novel. This specification is focused on 
 and creating a list of the most common JSON fields for cross compatibility reasons.
 
 
-# File Specification
+File Specification
+==================
 
 Each file is a plain text file, UTF-8 encoded. It should end each line with Unix style newlines (0x0A).
 
@@ -35,6 +36,7 @@ Each file should begin with a line declaring the file format and file format ver
 (`!` - 0x21) so that it automatically sorts to the front of the file.
 
 Example:
+
 ```
 !OpenWayback-CDXJ 1.0
 ```
@@ -50,12 +52,14 @@ the major version number indicates a change that is not backwards compatible. It
 different major version numbers.
 
 
-## Resource Entries
+Resource Entries
+----------------
 
 Following the header lines, each additional line should represent exactly one resource in a web archive. Typically in a WARC or ARC file, although the exact storage of the resource is not defined by this specification.
 
 
-# Field Specification
+Field Specification
+===================
 
 Each line is composed of five fields as described in the next capter. 
 
@@ -65,7 +69,9 @@ Additionally, only the last (JSON block) field may begin with an opening curly b
 
 The first four fields are collectively known as the *sortable* fields.
 
-## Searchable URI
+
+Searchable URI
+--------------
 
 The first field is a searchable version of the URI that this resource refers to.
 
@@ -95,7 +101,8 @@ Once you include the third step of dropping the scheme.
 The first field may not begin with a bang character (`!` - 0x21). As these are not allowed in URIs, this is unlikely to cause any issues.
 
 
-## Timestamp
+Timestamp
+---------
 
 The second field is a timestamp. It should correspond to the WARC-Date timestamp as of WARC 1.1.
 
@@ -119,7 +126,8 @@ of the timestamp should match the accuracy that is available in the WARC (or oth
 **Note:** All timestamps should be in UTC.
 
 
-## Content Digest
+Content Digest
+--------------
 
 The third field should contain a Base32 encoded SHA-1 digest of the contents of the URI or a simple dash (`-` - 0x2D) if the URI refers 
 to a record without a content block. The algorithm prefix (e.g. `sha1:`) often used where multiple hashing algorithms may be used, is
@@ -133,7 +141,8 @@ with a mixture of digest from different algorithms here, we chose the most commo
 algorithms may be included in the JSON blob.
 
 
-## Record Type
+Record Type
+-----------
 
 Indicates what type of record the current line refers to. This field is fully compatible with WARC 1.0 (ISO 28500) definition of 
 WARC-Type (chapter 5.5 and chapter 6). 
@@ -147,7 +156,8 @@ E.g.
 * **revisit** - Suitable for any record of a response from a server to a specific request, where the content body is equal to that of another record.
 
 
-## JSON 
+JSON 
+----
 
 The fifth and final field is a single line JSON block. This should contain fully valid JSON data. The only limitation, beyond those 
 imposed by JSON encoding rules, is that this may not contain any newline characters, either in Unix (0x0A) or Windows form (0x0D0A). The 
@@ -175,19 +185,23 @@ Defined JSON keys:
 
 
 
-# Sorting File / Index
+Sorting File / Index
+====================
 
 
-# Appendices 
+Appendices 
+==========
 
-## A - Canonicalization
+A Canonicalization
+--------------------
 
 Canonicalization is applied to URIs to remove trivial differences in the URIs that do not reflect that the URI reference different resources. Examples include removing session ID parameters, unneccessary port declerations (e.g. :80 when crawling HTTP).
 
 OpenWayback implements its own canonicalization process. Typically, it will be applied to the searchable URIs in CDXJ files. You can, however, use any canonicalization scheme you care for (including none). You must simple ensure that the same canonicalization process is applied to the URIs when performing searches. Otherwise they may not match correctly.
 
 
-## B - Sort-friendly URI Reordering Transform (SURT)
+B Sort-friendly URI Reordering Transform (SURT)
+-----------------------------------------------
 
 SURT is a transformation applied to URIs which makes their left-to-right representation better match the natural hierarchy of domain names.
 
@@ -196,7 +210,8 @@ A URI <scheme://domain.tld/path?query> has SURT form <scheme://(tld,domain,)/pat
 Conversion to SURT form also involves making all characters lowercase, and changing the 'https' scheme to 'http'. Further, the '/' after a URI authority component -- for example, the third slash in a regular HTTP URI -- will only appear in the SURT form if it appeared in the plain URI form. (This convention proves important when using real URIs as a shorthand for SURT prefixes, as described below.)
 
 
-## C - warcfile URI Scheme
+C 'warcfile' URI Scheme
+-----------------------
 
 The 'warcfile' URI scheme shall be assumed to have the following structure:
 
@@ -216,3 +231,14 @@ warcfile:warcfile:IAH-20070824123353-00393-heritrix2.nb.no.arc.gz#25523382
 ```
 
 To fully resolve a URI with this scheme, an index mapping WARC filenames to specific locations is needed.
+
+
+D Example CDXJ File
+-------------------
+
+```
+!OpenWayback-CDXJ 1.0
+
+
+
+```

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -1,5 +1,5 @@
 ---
-title: CDXJ OpenWayback File Format
+title: OpenWayback CDXJ File Format
 type: specification
 status: proposed
 version: 1.0

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -192,6 +192,13 @@ Defined JSON keys:
 * **rod** (*recommended*) - Revisit Original Date. Only valid for records of type *revisit*. Contains the timestamp (equivalent to sortable field #2) of the record that this record is considered a revisit of.
 * **roi** - Revisit Original record ID. Only valid for records of type *revisit*. Contains the record ID of the record that this record is considered a revisit of.
 
+Additionally, the four sortable fields can be redundantly stored in the JSON block, if so desired using the following keys:
+
+1. Searchable URI - **ssu** (**s**ortable **s**earchable **U**RI)
+2. Timestamp - **sts** (**s**ortable **t**ime**s**tamp)
+3. Content Digest - **scd** (**s**ortable **c**ontent **d**igest)
+4. Record Type - **srt**  (**s**ortable **r**ecord **t**ype)
+
 To reduce the possibility of incompatibility with future versions of CDXJ, the use of custom keys longer than 3 characters is recommended.
 
 Alternatively, new keys may be discussed and agreed upon by the OpenWayback community prior to a revised CDXJ version being released. 
@@ -202,12 +209,13 @@ Sorting File / Index
 ====================
 
 A sorted CDXJ file is considered a CDXJ *index*, allowing lookup on URI (and timestamp) using simple binary searches. The CDXJ structure 
-is designed to facilitate this, but the sorting is outside the scope of this document. A non-sorted CDXJ file is still valid as far as
-this specification goes. It is just not usable for searching.
+is designed to facilitate this. A non-sorted CDXJ file is still valid as far as this specification goes. It is just not usable for
+searching. 
 
-Furthermore, the structure of the CDXJ is designed so that using common sorting tools (e.g. GNU "sort" utility) works as expected. Do
-note that you may need to correctly configure the collation settings (how it orders the characters when sorting). This must match the
-expectation of the software using the CDXJ file (typically OpenWayback). Consult the software's documentation for further details.
+When sorted, the sorting should be done based on the native byte values of the characters. This is equivalent to using the GNU sort with 
+the collation settings `LC_ALL=C`.
+
+The structure of the CDXJ is designed so that using common sorting tools (e.g. GNU sort utility) works as expected. Provided that the correct collation settings are set as described above.
 
 
 Appendices 
@@ -254,7 +262,7 @@ The `<offset>` is the number of bytes from the start of the WARC when the releva
 Example URI:
 
 ```
-warcfile:warcfile:IAH-20070824123353-00393-heritrix2.nb.no.arc.gz#25523382
+warcfile:IAH-20070824123353-00393-heritrix2.nb.no.arc.gz#25523382
 ```
 
 To fully resolve a URI with this scheme, an index mapping WARC filenames to specific locations is needed.

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -5,7 +5,7 @@ status: proposed
 version: 1.0
 numbered: true
 latest: true
-version-of: cdxj-openwayback-format
+version-of: openwayback-cdxj-format
 ---
 
 Preamble
@@ -15,11 +15,14 @@ This specification covers the CDXJ file format used by OpenWayback 3.0.0 (and la
 WARC and ARC files) and make them searchable via a resource resolution service.
 
 The format builds on the CDX file format originally developed by the Internet Archive for the indexing behind the WaybackMachine. 
-This specification build on it by simplifying the primary fields while adding a flexible JSON 'blob' to each resource, allowing 
+This specification build on it by simplifying the primary fields while adding a flexible JSON 'block' to each resource, allowing 
 high flexiblity in the inclusion of secondary data.
 
 The use of a JSON in this manner is not novel. This specification is focused on enumarating the exact fields *outside* the JSON
-and creating a list of the most common JSON fields for cross compatibility reasons.
+and creating a list of the most common JSON fields for cross compatibility reasons. For the purposes of this document, CDXJ will be understood to refer to this particular specification.
+
+While we recognize that this format may have wider application (e.g. for data exchange) the primary purpose of this specification is
+to establish a file format suitable for creating a simple, URI keyed, index to the resources of a web archive.
 
 
 File Specification
@@ -47,7 +50,7 @@ The is to accomodate the merging of multiple CDXJ files that may be generated at
 It is permissible to mix minor version numbers (e.g. `1.0` and `1.1`) as minor versions are required to be backwards compatible.
 In this scenario, parsing software should treat the entire file based on the highest observed version number.
 
-It is not permissible to mix major version numbers (e.g. `1.0` and `2.0`) in the same file. It is understood that a bump in
+It is not permissible to mix major version numbers (e.g. `1.0` and `2.0`) in the same file. It is understood that an increase in
 the major version number indicates a change that is not backwards compatible. It is not possible to merge CDXJ files with 
 different major version numbers.
 
@@ -55,15 +58,15 @@ different major version numbers.
 Resource Entries
 ----------------
 
-Following the header lines, each additional line should represent exactly one resource in a web archive. Typically in a WARC or ARC file, although the exact storage of the resource is not defined by this specification.
+Following the header lines, each additional line should represent exactly one resource in a web archive. Typically in a WARC (ISO 28500) or ARC file, although the exact storage of the resource is not defined by this specification.
 
 
 Field Specification
 ===================
 
-Each line is composed of five fields as described in the next capter. 
+Each line is composed of five fields. 
 
-The fields are seperated by spaces (0x20). Consequently, spaces may not appear in the fields, except for the last field (JSON blob). 
+The fields are seperated by spaces (0x20). Consequently, spaces may not appear in the fields, except for the last field (JSON block). 
 
 Additionally, only the last (JSON block) field may begin with an opening curly brace (`{` - 0x7B).
 
@@ -81,7 +84,7 @@ By *searchable*, we mean that the following transformations have been applied to
 2. Sort-friendly URI Reordering Transform (SURT) - See Appendix B
 3. The scheme is dropped from the SURT format
 
-**Note:** While this is extremly simmilar to other CDX and CDXJ implementations, we note that a lot of them get the SURT format wrong. 
+**Note:** While this is extremly similar to other CDX and CDXJ implementations, we note that a lot of them get the SURT format wrong. 
 Most notably by omitting the starting parenthesis or dropping the trailing comma in the domain name.
 
 E.g. in using OpenWayback 2's CDX server the URL `http://example.com/' would translate to:
@@ -90,15 +93,15 @@ E.g. in using OpenWayback 2's CDX server the URL `http://example.com/' would tra
 com,example)/
 ```
 
-The correct SURT transformation is:
+The correct SURT transformation is ...
 
 ```
 (com,example,)/
 ```
 
-Once you include the third step of dropping the scheme. 
+... once you include the third step of dropping the scheme. 
 
-The first field may not begin with a bang character (`!` - 0x21). As these are not allowed in URIs, this is unlikely to cause any issues.
+Note that the first field may not begin with a bang character (`!` - 0x21). 
 
 
 Timestamp
@@ -108,17 +111,13 @@ The second field is a timestamp. It should correspond to the WARC-Date timestamp
 
 > A UTC timestamp as described in the W3C profile of ISO8601 [W3CDTF].
 > The timestamp shall represent the instant that data capture for record
-> creation began. Multiple records written as part of a single capture
-> event (see section 5.7) shall use the same WARC-Date, even though the
-> times of their writing will not be exactly synchronized. 
+> creation began. [...]
 > 
 > WARC-Date may be specified at any of the six levels of granularity
 > described in [W3CDTF]. If WARC-Date includes a decimal fraction of a
 > second, the decimal fraction of a second shall have a minimum of 1
 > digit and a maximum of 9 digits. WARC-Date should be specified with as
-> much precision as is accurately known. This document recommends no
-> particular algorithm for access software to choose a record by date
-> when an exact match is not available.
+> much precision as is accurately known. 
 
 This is a notable departure from the original CDX format, that used a somewhat truncated timestamp (YYYYMMDDhhmmss). The level of accuracy
 of the timestamp should match the accuracy that is available in the WARC (or other source material).
@@ -129,9 +128,11 @@ of the timestamp should match the accuracy that is available in the WARC (or oth
 Content Digest
 --------------
 
-The third field should contain a Base32 encoded SHA-1 digest of the contents of the URI or a simple dash (`-` - 0x2D) if the URI refers 
-to a record without a content block. The algorithm prefix (e.g. `sha1:`) often used where multiple hashing algorithms may be used, is
+The third field should contain a Base32 encoded SHA-1 digest of the contents of the URI. The algorithm prefix (e.g. `sha1:`) often used where multiple hashing algorithms may be used, is
 omitted in this case.
+
+Note that this is the digest of the payload or content of the record, excluding such things as, for example, HTTP headers. Records that 
+refer to resources without such a payload (e.g. HTTP redirects) use a simple dash (`-` - 0x2D) for this field to indicate this. 
 
 In the case of revisit records and continuation records (or others that rely on a second record to fully replay the content), this should
 be the digest of the original/full content. Additional digests may be included in the JSON blob.
@@ -161,7 +162,7 @@ JSON
 
 The fifth and final field is a single line JSON block. This should contain fully valid JSON data. The only limitation, beyond those 
 imposed by JSON encoding rules, is that this may not contain any newline characters, either in Unix (0x0A) or Windows form (0x0D0A). The 
-first occurance of a 0x0A constitutes the end of this field.
+first occurance of a 0x0A constitutes the end of this field (and the record).
 
 The order of key/value pairs within the JSON block is unspecified. It is not expected that records can be sorted, in any way, on the JSON 
 field.
@@ -171,7 +172,7 @@ fields are required.
 
 Defined JSON keys:
 * **uri** (*required*) - The value should be the non-transformed URI used for the searchable URI (first sortable field).
-* **hsc** - HTTP Status Code. Applicable for *response* records for HTTP(S) URIs
+* **hsc** - HTTP Status Code. Applicable for *response* records for HTTP(S) URIs.
 * **mct** - Media Content Type (MIME type). For HTTP(S) *response* records this is typically the "Content-Type" from the HTTP header. This field, however, does not specify the origin of the information. It may be used to include content type that was derived from content analysis or other sources.
 * **ref** (*required) - A URI that resolves to the resource that this record refers to. This can be any well defined URI scheme. For the most common web archive use case of warc filename plus offset, see Appendix C. For other use cases, existing schemes can be used or new ones devised.
 * **rid** (*recommended*) - Record ID. Typically WARC-Record-ID or equivalent if not using WARCs. In a mixed environment, you should ensure that record ID is unique.
@@ -195,19 +196,25 @@ Appendices
 A Canonicalization
 --------------------
 
-Canonicalization is applied to URIs to remove trivial differences in the URIs that do not reflect that the URI reference different resources. Examples include removing session ID parameters, unneccessary port declerations (e.g. :80 when crawling HTTP).
+Canonicalization is applied to URIs to remove trivial differences in the URIs that do not reflect that the URI reference different 
+resources. Examples include removing session ID parameters, unneccessary port declerations (e.g. :80 when crawling HTTP).
 
-OpenWayback implements its own canonicalization process. Typically, it will be applied to the searchable URIs in CDXJ files. You can, however, use any canonicalization scheme you care for (including none). You must simple ensure that the same canonicalization process is applied to the URIs when performing searches. Otherwise they may not match correctly.
+OpenWayback implements its own canonicalization process. Typically, it will be applied to the searchable URIs in CDXJ files. You can, 
+however, use any canonicalization scheme you care for (including none). You must simple ensure that the same canonicalization process is 
+applied to the URIs when performing searches. Otherwise they may not match correctly.
 
 
 B Sort-friendly URI Reordering Transform (SURT)
 -----------------------------------------------
 
-SURT is a transformation applied to URIs which makes their left-to-right representation better match the natural hierarchy of domain names.
+SURT is a transformation applied to URIs which makes their left-to-right representation better match the natural hierarchy of domain 
+names.
 
 A URI <scheme://domain.tld/path?query> has SURT form <scheme://(tld,domain,)/path?query>.
 
-Conversion to SURT form also involves making all characters lowercase, and changing the 'https' scheme to 'http'. Further, the '/' after a URI authority component -- for example, the third slash in a regular HTTP URI -- will only appear in the SURT form if it appeared in the plain URI form. (This convention proves important when using real URIs as a shorthand for SURT prefixes, as described below.)
+Conversion to SURT form also involves making all characters lowercase, and changing the 'https' scheme to 'http'. Further, the '/' after 
+a URI authority component -- for example, the third slash in a regular HTTP URI -- will only appear in the SURT form if it appeared in 
+the plain URI form. (This convention proves important when using real URIs as a shorthand for SURT prefixes, as described below.)
 
 
 C 'warcfile' URI Scheme

--- a/specifications/cdx-format/cdxj-openwayback/index.md
+++ b/specifications/cdx-format/cdxj-openwayback/index.md
@@ -171,6 +171,7 @@ It is legal to store any amount of data in the JSON block. The following keys, h
 fields are required.
 
 Defined JSON keys:
+
 * **uri** (*required*) - The value should be the non-transformed URI used for the searchable URI (first sortable field).
 * **hsc** - HTTP Status Code. Applicable for *response* records for HTTP(S) URIs.
 * **mct** - Media Content Type (MIME type). For HTTP(S) *response* records this is typically the "Content-Type" from the HTTP header. This field, however, does not specify the origin of the information. It may be used to include content type that was derived from content analysis or other sources.

--- a/specifications/warc-format/warc-1.1/index.md
+++ b/specifications/warc-format/warc-1.1/index.md
@@ -361,6 +361,8 @@ defined-field = WARC-Type
               | WARC-Payload-Digest
               | WARC-IP-Address
               | WARC-Refers-To
+              | WARC-Refers-To-Target-URI
+              | WARC-Refers-To-Date
               | WARC-Target-URI
               | WARC-Truncated
               | WARC-Warcinfo-ID
@@ -608,6 +610,35 @@ another record it describes. The WARC-Refers-To field may also be used
 to associate a record of type 'revisit' or 'conversion' with the
 preceding record which helped determine the present record content. The
 WARC-Refers-To field shall not be used in 'warcinfo', 'response',
+‘resource’, 'request', and 'continuation' records.
+
+WARC-Refers-To-Target-URI
+-------------------------
+
+The WARC-Target-URI of a record for which the present record is 
+considered a revisit of.
+
+    WARC-Refers-To-Target-URI = "WARC-Refers-To-Target-URI" ":" uri
+
+The WARC-Refers-To-Target-URI field may be used to help associate a record of 
+type 'revisit' with the another record which helped determine the 
+present record content. The WARC-Refers-To-Target-URI field shall not be 
+used in 'warcinfo', 'response','metadata',´conversion',
+‘resource’, 'request', and 'continuation' records.
+
+WARC-Refers-To-Date
+-------------------------
+
+The WARC-Date of a record for which the present record is 
+considered a revisit of.
+
+    WARC-Refers-To-Date = "WARC-Refers-To-Date" ":" w3c-iso8601
+    w3c-iso8601 = <YYYY-MM-DDThh:mm:ssZ>
+    
+The WARC-Refers-To-Date field may be used to help associate a record of 
+type 'revisit' with the another record which helped determine the 
+present record content. The WARC-Refers-To-Target-URI field shall not be 
+used in 'warcinfo', 'response','metadata',´conversion',
 ‘resource’, 'request', and 'continuation' records.
 
 WARC-Target-URI
@@ -1043,7 +1074,9 @@ See annex C.6 below for an example of a ‘revisit’ record.
 
 This 'revisit' profile may be used whenever a subsequent consideration
 of a URI provides payload content which a strong digest function, such
-as SHA-1, indicates is identical to a previously recorded version.
+as SHA-1, indicates is identical to a previously recorded version. It
+is not necessary that the URI of the original capture and the revisit
+be identical.
 
 To indicate this profile, use the URI:
 
@@ -1058,7 +1091,8 @@ case a Content-Length of zero must be written. If a record block is
 present, it shall be interpreted the same as a 'response' record type
 for the same URI, but truncated to avoid storing the duplicate content.
 A WARC-Truncated header with reason 'length' shall be used for any
-identical-digest truncation.
+identical-digest truncation. It is recommended that server response 
+headers be preserved in the revisit record in this manner.
 
 For records using this profile, the payload is defined as the original
 payload content whose digest value was unchanged.
@@ -1066,6 +1100,17 @@ payload content whose digest value was unchanged.
 Using a WARC-Refers-To header to identify a specific prior record from
 which the matching content can be retrieved is recommended, to minimize
 the risk of misinterpreting the 'revisit' record.
+
+The following two optional fields can also be used to identify the 
+correct original record. Their use is recommended.
+
+WARC-Refers-To-Target-URI. Its value should be equal to the 
+WARC-Target-URI in the WARC record that the current record is considered 
+a duplicate of. 
+
+WARC-Refers-To-Date. Its value should be equal to the WARC-Date in the 
+WARC record that the current record is considered a duplicate of.
+
 
 ### Profile: Server Not Modified
 
@@ -1089,6 +1134,11 @@ taken.
 Using a WARC-Refers-To header to identify a specific prior record from
 which the unmodified content can be retrieved is recommended, to
 minimize the risk of misinterpreting the 'revisit' record.
+
+WARC-Refers-To-Date may be optionally used to help resolve the original 
+capture. Its value should be equal to the WARC-Date in the 
+WARC record that the current record is considered a duplicate of. Its
+use is recommended.
 
 ### Other profiles
 

--- a/specifications/warc-format/warc-1.1/index.md
+++ b/specifications/warc-format/warc-1.1/index.md
@@ -637,7 +637,7 @@ considered a revisit of.
     
 The WARC-Refers-To-Date field may be used to help associate a record of 
 type 'revisit' with the another record which helped determine the 
-present record content. The WARC-Refers-To-Target-URI field shall not be 
+present record content. The WARC-Refers-To-Date field shall not be 
 used in 'warcinfo', 'response','metadata',´conversion',
 ‘resource’, 'request', and 'continuation' records.
 


### PR DESCRIPTION
Deals with issue #10 : WARC revision 1.1 (augmentation): add new named fields for deduplication.

Based on the adopted practice from 'Proposal for Standardizing the
Recording of Arbitrary Duplicates in WARC Files 1.0':
https://iipc.github.io/warc-specifications/specifications/warc-deduplication/recording-arbitrary-duplicates-1.0/

**I'm opening this PR to solicit feedback and review. It is not yet ready for merging!**
