### PR TITLE
revise WARC-Date spec

### DIFF
--- a/specifications/warc-format/warc-1.1/index.md
+++ b/specifications/warc-format/warc-1.1/index.md
@@ -449,16 +449,17 @@ All records shall have a Content-Length field.
 WARC-Date (mandatory)
 ---------------------
 
-A 14-digit UTC timestamp formatted according to YYYY-MM-DDThh:mm:ssZ,
-described in the W3C profile of ISO8601 \[W3CDTF\]. The timestamp
-shall represent the instant that data capture for record creation
-began. Multiple records written as part of a single capture event (see
-section 5.7) shall use the same WARC-Date, even though the times of
-their writing will not be exactly synchronized.
+A UTC timestamp as described in the W3C profile of ISO8601 [W3CDTF]. The timestamp shall represent the instant that data capture for record creation began. Multiple records written as part of a single capture event (see section 5.7) shall use the same WARC-Date, even though the times of their writing will not be exactly synchronized. WARC-Date may be specified at any of the six levels of granularity described in [W3CDTF]. If WARC-Date includes a decimal fraction of a second, the decimal fraction of a second shall have a minimum of 1 digit and a maximum of 9 digits. WARC-Date should be specified with as much precision as is accurately known. This document recommends no particular algorithm for choosing a record by date when an exact match is not available.
 
-    WARC-Date = "WARC-Date" ":" w3c-iso8601
-    w3c-iso8601 = <YYYY-MM-DDThh:mm:ssZ>
-
+    WARC-Date   = "WARC-Date" ":" w3c-iso8601
+    w3c-iso8601 = w3c-iso8601-14+ | w3c-iso8601-14 | w3c-iso8601-12 | w3c-iso8601-10 | w3c-iso8601-8 | w3c-iso8601-6 | w3c-iso8601-4
+    w3c-iso8601-14+ = <YYYY-MM-DDThh:mm:ss.sZ>
+    w3c-iso8601-14  = <YYYY-MM-DDThh:mm:ssZ>
+    w3c-iso8601-12  = <YYYY-MM-DDThh:mmZ>
+    w3c-iso8601-8   = <YYYY-MM-DD>
+    w3c-iso8601-6   = <YYYY-MM>
+    w3c-iso8601-4   = <YYYY>
+    
 All records shall have a WARC-Date field.
 
 WARC-Type (mandatory)
@@ -1808,6 +1809,8 @@ WARC-Refers-To: <i>WARC-Record ID of
 
 Document History
 ================
+
+*2015-07-31* -- Revise WARC-Date specification to permit values with varying levels of precision.
 
 *2015-07-10* -- Version 1.0 of the specification copied to act as the baseline for version 1.0. Added this document history and updated metadata in header.
 


### PR DESCRIPTION
Revise WARC-Date specification to permit values with varying levels of precision. It is the same as the "Alternative Proposed Revised Spec"
from http://nlevitt.github.io/warc-specifications/specifications/warc-date/allow-more-precise.html but with the addition of the sentence "This document recommends no particular algorithm for choosing a record by date when an exact match is not available." I also added an entry to Document History. See also https://github.com/iipc/warc-specifications/pull/6