### PR TITLE
Proposal: WARC 1.0 Errata: uri and record-id BNF grammar

### DIFF
--- a/_includes/_about.md
+++ b/_includes/_about.md
@@ -8,6 +8,14 @@
 {% assign previous-version = op %}
 {% endif %}
 {% endif %}
+{% if page.version == op.version %}
+{%   if page.errata-for and page.errata-for == op.version-of %}
+{%     assign errata-for = op %}
+{%   endif %}
+{%   if page.version-of and page.version-of == op.errata-for %}
+{%     assign errata = op %}
+{%   endif %}
+{% endif %}
 {% endfor %}
   <div class="panel panel-default" id="issues_panel">
     <div class="panel-heading">
@@ -19,6 +27,10 @@
     <dl>
     <dt>Title<dt>
     <dd>{{ page.title }}{% if page.version %} {{ page.version }}{% endif %}&nbsp;<span class="badge spec-badge-status-{{ page.status }}">{{ page.status }}</span></dd>
+{% if errata-for %}
+    <dt>Errata for</dt>
+    <dd><a href="{{ site.baseurl }}{{ errata-for.url }}">{{errata-for.title}} {{errata-for.version}}</a></dd>
+{% else %}
     <dt>Latest version</dt>
 {% if latest-version %}
     <dd><a href="{{ site.baseurl }}{{ latest-version.url }}">See version {{ latest-version.version }}</a></dd>
@@ -30,6 +42,11 @@
     <dd><a href="{{ site.baseurl }}{{ previous-version.url }}">See version {{ previous-version.version }}</a></dd>
 {% else %}
     <dd>None</dd>
+{% endif %}
+{% endif %}
+{% if errata %}
+    <dt>Errata</dt>
+    <dd><a href="{{ site.baseurl }}{{ errata.url }}">See the errata for version {{ page.version }}</a></dd>
 {% endif %}
 {% if page.version-of %}
     <dt>Issues</dt>

--- a/specifications/warc-format/warc-1.0/errata.md
+++ b/specifications/warc-format/warc-1.0/errata.md
@@ -1,0 +1,63 @@
+---
+title: The WARC Format Errata
+type: errata
+status: proposed
+version: 1.0
+numbered: true
+errata-for: warc-format
+---
+
+The following errors will be corrected at the next revision of the
+standard.
+
+URI and Record ID BNF Grammar
+=============================
+
+Section 4, grammar definition 2, line 32 currently reads:
+
+    uri            = "<" <'URI' per RFC3986> ">"
+
+It should read:
+
+    record-id      = "<" uri ">"
+    uri            = <'URI' per RFC3986>
+
+- - -
+
+The grammar definition in section 5.7 currently reads:
+
+    WARC-Concurrent-To = "WARC-Concurrent-To" ":" uri
+
+It should read:
+
+    WARC-Concurrent-To = "WARC-Concurrent-To" ":" record-id
+
+- - -
+
+The grammar definition in section 5.11 currently reads:
+
+    WARC-Refers-To = "WARC-Refers-To" ":" uri
+
+It should read:
+
+    WARC-Refers-To = "WARC-Refers-To" ":" record-id
+
+- - -
+
+The grammar defintion in section 5.14 currently reads:
+
+    WARC-Warcinfo-ID = "WARC-Warcinfo-ID" ":" uri
+
+It should read:
+
+    WARC-Warcinfo-ID = "WARC-Warcinfo-ID" ":" record-id
+
+- - -
+
+The grammar definition in section 5.20 currently reads:
+
+    WARC-Segment-Origin-ID = "WARC-Segment-Origin-ID" ":" uri
+
+It should read:
+
+    WARC-Segment-Origin-ID = "WARC-Segment-Origin-ID" ":" record-id


### PR DESCRIPTION
I propose creating an errata document for WARC 1.0. I am unfamiliar with standards processes so I apologise if this is not the appropriate way of doing so. Even if it is not possible to create official ISO errata for the standard I think it would be useful for implementors if we maintain an unofficial errata document.

Addresses #23. Additional discussion and 1.1 revision in #24.
