### PR TITLE
WARC Extensions for HTTP/2 proposal

### DIFF
--- a/.github/ISSUE_TEMPLATE/protocol.md
+++ b/.github/ISSUE_TEMPLATE/protocol.md
@@ -1,0 +1,16 @@
+### Protocol name
+
+> e.g. FTP, HTTP/2 over cleartext TCP
+
+### Protocol identifier
+
+> Identifiers should be a lowercase ASCII string of the form "name/version".
+> The slash character and version should be omitted if the protocol doesn't
+> have multiple versions or is fully backwards compatible.
+>
+> Consider reusing identifiers from the following registry where posibble:
+> https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
+
+### Specification URL (optional)
+
+> URL of a document describing the protocol such as an RFC.

--- a/specifications/warc-http2/index.md
+++ b/specifications/warc-http2/index.md
@@ -1,0 +1,149 @@
+---
+title: WARC Extensions for HTTP/2
+status: proposed
+latest: true
+version-of: warc-http2
+version: 0.1
+---
+
+[HTTP/2] defines a new binary protocol which is semantically highly compatible
+with HTTP/1 but adds new transport features such as header compression, request
+multiplexing and server push.
+
+[HTTP/2]: https://tools.ietf.org/html/rfc7540
+
+Backwards compatiblity dictates that HTTP/2 servers be able to serve the same
+content over HTTP/1 so current practice when crawling is to make all requests
+over HTTP/1. However browser-based archiving tools may not have control over
+protocol negotiation and therefore may have no choice but to deal with content
+that was delivered via HTTP/2. It may also be desirable for crawlers to be able
+to make use of HTTP/2 for performance reasons.
+
+As HTTP/2 allows connection multiplexing and is typically encrypted with TLS
+we cannot simply store the bytes received from the TCP stream as we do with
+HTTP/1. Tools that are browser-based or use a HTTP/2 code library may have 
+ready access to decoded headers but not to the raw protocol bytes. Finally, 
+storing only the binary H2 protocol would pose a compatiblity problem for
+WARC reading tools that only understand HTTP/1.1 and increase the complexity
+of reading WARC files.
+
+Therefore this document proposes a mechanism for storing HTTP/2 requests and
+responses in their semantically equivalent HTTP/1.1 form and defines an
+extension WARC header field recording the original protocol version.
+
+Future versions of these extensions may specify how extra HTTP/2-specific
+information may be optionally encoded in extension fields or metadata records.
+This version however does not. Anyone with a use case for storing
+HTTP/2-specific information is encouraged to join the discussion or even submit
+a proposal via the [warc-specifications Github project].
+
+[warc-specifications Github project]: https://github.com/iipc/warc-specifications
+
+# WARC-Original-Protocol field definition
+
+The WARC-Original-Protocol field denotes that the protocol messages in the
+record block was originally encoded using a different protocol.
+
+    WARC-Original-Protocol = "WARC-Original-Protocol" ":" protocol
+    protocol = "HTTP/2"
+
+The WARC-Original-Protocol field should not be used when the record block
+contains the original protocol and the protocol can be determined from the
+value of the WARC record's Content-Type field.
+
+This document defines a single protocol value "HTTP/2". Other protocol values
+may be defined by future extensions.
+
+The WARC-Original-Protocol field may be used in 'request', 'response',
+'resource' and 'metadata' records and shall not be used in 'warcinfo',
+'conversion' and 'continuation' records.
+
+# Encoding HTTP/2 messages as HTTP/1.1
+
+When the decoded header information for HTTP/2 requests and responses is
+available they should be formatted WARC 'request' and 'response' records
+with the header encoded as HTTP/1.1. When header information is unavailable a
+'resource' record should instead be used.
+
+In all three record types the fact the exchange originally occurred via HTTP/2
+should be recorded by including a WARC-Original-Protocol field with the value
+"HTTP/2".
+
+Example request record:
+
+    WARC/1.1
+    WARC-Record-ID: <urn:uuid:a6aadb41-1b2f-46e0-9e94-74339cbc9875>
+    WARC-Type: request
+    WARC-Date: 2018-07-12T16:44:13.123Z
+    WARC-Target-URI: https://example.org/
+    WARC-Original-Protocol: HTTP/2
+    Conent-Length: 75
+    Content-Type: application/http;msgtype=request
+
+    GET / HTTP/1.1
+    host: example.org
+    user-agent: example/1.0
+    accept: */*
+
+Example response record:
+
+    WARC/1.1
+    WARC-Record-ID: <urn:uuid:5269bd38-547a-4f77-a285-8d30ec6e0b54>
+    WARC-Type: response
+    WARC-Date: 2018-07-12T16:44:13.123Z
+    WARC-Target-URI: https://example.org/
+    WARC-Original-Protocol: HTTP/2
+    WARC-IP-Address: 192.0.2.1
+    Conent-Length: 12131
+    Content-Type: application/http;msgtype=response
+
+    HTTP/1.1 200 
+    server: Apache
+    content-type: text/html;charset=UTF-8
+    cache-control: max-age=43200
+    expires: Thu, 12 Jul 2018 16:44:26 GMT
+    date: Thu, 12 Jul 2018 04:44:26 GMT
+    content-length: 11930
+
+    [text/html payload follows]
+
+Example resource record:
+
+    WARC/1.1
+    WARC-Record-ID: <urn:uuid:5269bd38-547a-4f77-a285-8d30ec6e0b54>
+    WARC-Type: resource
+    WARC-Date: 2018-07-12T16:44:13.123Z
+    WARC-Target-URI: https://example.org/
+    WARC-Original-Protocol: HTTP/2
+    Content-Length: 12131
+    Content-Type: text/html;charset=UTF-8
+    
+    [text/html payload follows]
+
+## Handling of reason phrases in HTTP responses
+ 
+HTTP/2 does not define a way to carry the HTTP/1 reason phrase in response
+messages. The reason-phrase field is mandatory in HTTP/1.1 responses but may
+be an empty string. Therefore the status line must be written with a trailing
+space:
+
+    "HTTP/1.1" SP status-code SP CRLF
+
+## Non-standard HTTP/2 textual representations
+
+Some tools (notably curl) for debugging purposes display a non-standard textual
+representation of HTTP/2 formatted similar to HTTP/1 but with a version number
+of "HTTP/2":
+
+    GET / HTTP/2
+    Host: example.org
+    User-Agent: curl/7.59.0
+    Accept: */*
+
+This is not a valid HTTP message and for interoperability programs writing
+WARC files must not write records like this. Programs translating WARC/2
+messages to HTTP/1.1 should write messages which obey grammar defined in
+[RFC 7230]. The original protocol version should instead be indicated using the
+WARC-Original-Protocol field defined above. 
+
+[RFC 7230]: https://tools.ietf.org/html/rfc7230

--- a/specifications/warc-http2/index.md
+++ b/specifications/warc-http2/index.md
@@ -44,15 +44,18 @@ a proposal via the [warc-specifications Github project].
 The WARC-Original-Protocol field denotes that the protocol messages in the
 record block was originally encoded using a different protocol.
 
-    WARC-Original-Protocol = "WARC-Original-Protocol" ":" protocol
-    protocol = "HTTP/2"
+    WARC-Original-Protocol = "WARC-Original-Protocol" ":" protocol-id
+    protocol-id = "h2"   ; HTTP/2 over TLS
+                | "h2c"  ; HTTP/2 over cleartext TCP
+                | <other protocol identifier>
 
 The WARC-Original-Protocol field should not be used when the record block
 contains the original protocol and the protocol can be determined from the
 value of the WARC record's Content-Type field.
 
-This document defines a single protocol value "HTTP/2". Other protocol values
-may be defined by future extensions.
+Protocol identifiers from the
+[TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs registry](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids)
+may be used.
 
 The WARC-Original-Protocol field may be used in 'request', 'response',
 'resource' and 'metadata' records and shall not be used in 'warcinfo',
@@ -76,7 +79,7 @@ Example request record:
     WARC-Type: request
     WARC-Date: 2018-07-12T16:44:13.123Z
     WARC-Target-URI: https://example.org/
-    WARC-Original-Protocol: HTTP/2
+    WARC-Original-Protocol: h2
     Conent-Length: 75
     Content-Type: application/http;msgtype=request
 
@@ -92,7 +95,7 @@ Example response record:
     WARC-Type: response
     WARC-Date: 2018-07-12T16:44:13.123Z
     WARC-Target-URI: https://example.org/
-    WARC-Original-Protocol: HTTP/2
+    WARC-Original-Protocol: h2
     WARC-IP-Address: 192.0.2.1
     Conent-Length: 12131
     Content-Type: application/http;msgtype=response
@@ -114,7 +117,7 @@ Example resource record:
     WARC-Type: resource
     WARC-Date: 2018-07-12T16:44:13.123Z
     WARC-Target-URI: https://example.org/
-    WARC-Original-Protocol: HTTP/2
+    WARC-Original-Protocol: h2
     Content-Length: 12131
     Content-Type: text/html;charset=UTF-8
     

--- a/specifications/warc-http2/index.md
+++ b/specifications/warc-http2/index.md
@@ -47,15 +47,10 @@ record block was originally encoded using a different protocol.
     WARC-Original-Protocol = "WARC-Original-Protocol" ":" protocol-id
     protocol-id = "h2"   ; HTTP/2 over TLS
                 | "h2c"  ; HTTP/2 over cleartext TCP
-                | <other protocol identifier>
 
 The WARC-Original-Protocol field should not be used when the record block
 contains the original protocol and the protocol can be determined from the
 value of the WARC record's Content-Type field.
-
-Protocol identifiers from the
-[TLS Application-Layer Protocol Negotiation (ALPN) Protocol IDs registry](https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids)
-may be used.
 
 The WARC-Original-Protocol field may be used in 'request', 'response',
 'resource' and 'metadata' records and shall not be used in 'warcinfo',
@@ -69,8 +64,8 @@ with the header encoded as HTTP/1.1. When header information is unavailable a
 'resource' record should instead be used.
 
 In all three record types the fact the exchange originally occurred via HTTP/2
-should be recorded by including a WARC-Original-Protocol field with the value
-"HTTP/2".
+should be recorded by including a WARC-Original-Protocol field with the values
+"h2" for HTTP/2 over TLS or "h2c" for HTTP/2 of cleartext TCP.
 
 Example request record:
 


### PR DESCRIPTION
I've written up a formal version of the suggestion @ikreymer made in #15 for the handling of HTTP/2 records by encoding them as HTTP/1 with a new `WARC-Original-Protocol` header field. We probably should define how to record extra information of interest like server push events and so forth but they aren't semantically necessary so I think that can be done later either in a future revision of this extension or a separate document. I think it's important to ~~standardise~~ define a basic mechanism like this sooner rather than later as HTTP/2 is being widely adopted and tools like [warcreate](https://github.com/machawk1/warcreate) can't easily opt out like crawlers can.

I changed the WARC-Original-Protocol value from `HTTP/2.0` in Ilya's comment ~~to `HTTP/2` as that's the [official name](https://http2.github.io/faq/#is-it-http20-or-http2) for the protocol~~. [Edit: Now "h2" and "h2c" as they're the official protocol identifiers.]

I also added some guidelines explaining how to handle the reason phrase in the response message correctly and clarifying that programs should not write "HTTP/2" in the HTTP message header itself as doing so makes the message invalid.

Note that adopting this would not preclude later defining some future way for storing the full binary h2 protocol if anyone has a use case or strong desire for doing so.

Another alternative that's been discussed is using conversion records however conversion records are really only intended for converting payloads and don't really work as currently specified for translating protocols. Using conversion records would also not enable compatibility with existing tools.

Please consider, comment and correct. Any errors are my own, not Ilya's. ;-)