### PR TITLE
Removed extra text

### DIFF
--- a/specifications/warc-format/warc-1.1/index.md
+++ b/specifications/warc-format/warc-1.1/index.md
@@ -880,8 +880,6 @@ from which the response material was received.
 The contents of the 'response' record for other URI schemes are not
 specified in this International Standard.
 
-other URI schemes.
-
 'resource'
 ----------
 


### PR DESCRIPTION
When reading the spec I noticed this redundant text that could be removed.
