### PR TITLE
fix: capitalise warm in bibnum.bnf.fr link

### DIFF
--- a/specifications/warc-format/warc-1.1/index.md
+++ b/specifications/warc-format/warc-1.1/index.md
@@ -365,7 +365,7 @@ New named fields and new records types may be defined in extensions of
 the core format. However, it is strongly recommended to discuss any
 addition to verify that a suitable field or type doesn't already exist
 to avoid collision. Discussion should notably be held within the IIPC.
-More information on <http://bibnum.bnf.fr/warc/>.
+More information on <http://bibnum.bnf.fr/WARC/>.
 
 Named fields
 ============


### PR DESCRIPTION
The link resolves to a 404 unless capitalised.

<img width="1511" alt="Screenshot 2022-11-29 at 20 52 44" src="https://user-images.githubusercontent.com/30983976/204645253-3ad842e4-773b-4c80-9be7-150ba9d59487.png">

<img width="1503" alt="Screenshot 2022-11-29 at 20 53 00" src="https://user-images.githubusercontent.com/30983976/204645306-23d811be-782e-44d0-8220-717d00462ba3.png">
