### PR TITLE
Fix case-sensitive bibnum.bnf.fr links

### DIFF
--- a/primers/web-archive-formats/index.md
+++ b/primers/web-archive-formats/index.md
@@ -96,7 +96,7 @@ Comparison with ARC files
 Further Reading
 ---------------
 
-The official WARC specification is maintained by ISO. The draft versions are hosted at <http://bibnum.bnf.fr/warc/>, and mirrored here.
+The official WARC specification is maintained by ISO. The draft versions are hosted at <http://bibnum.bnf.fr/WARC/>, and mirrored here.
 
 For introductory information about the WARC format, see:
 

--- a/specifications/warc-format/warc-1.1-annotated/index.md
+++ b/specifications/warc-format/warc-1.1-annotated/index.md
@@ -393,7 +393,7 @@ New named fields and new records types may be defined in extensions of
 the core format. However, it is strongly recommended to discuss any
 addition to verify that a suitable field or type doesn't already exist
 to avoid collision. Discussion should notably be held within the IIPC.
-More information on <http://bibnum.bnf.fr/warc/>.
+More information on <http://bibnum.bnf.fr/WARC/>.
 
 Named fields
 ============


### PR DESCRIPTION
While reading the spec today, I noticed that the link to http://bibnum.bnf.fr/WARC/ is broken on some pages because the paths on that server are case sensitive, and some documents here (the v1.1 annotated spec, the web archive formats primer) list it as lower-case, when it should be upper-case. This fixes the links.

It looks like this has happened once before in #83, but that PR just missed some files.