### PR TITLE
Add proposed WARC-Cipher-Suite header.

### DIFF
--- a/_data/warc_fields.yml
+++ b/_data/warc_fields.yml
@@ -7,6 +7,9 @@
 - name: WARC-Block-Digest
   since: 1.0
   spec: WARC 1.1
+- name: WARC-Cipher-Suite
+  spec: issues/86
+  status: proposed
 - name: WARC-Concurrent-To
   since: 1.0
   spec: WARC 1.1


### PR DESCRIPTION
This adds the proposed `WARC-Cipher-Suite` WARC header to the list of headers.

The proposal is at https://github.com/iipc/warc-specifications/issues/86, which originally used `WARC-TLS-Cipher-Suite`, but in a later comment @acidus99 (who created the issue) wrote `WARC-Cipher-Suite` should be used instead, which is also in line with the release of Wget-AT 20231213.01 at https://github.com/ArchiveTeam/wget-lua/releases/tag/v1.21.3-at.20231213.01.